### PR TITLE
BasePolicy: always ensure OrgID is set

### DIFF
--- a/identity.go
+++ b/identity.go
@@ -100,6 +100,12 @@ func BasePolicy(next http.Handler) http.Handler {
 			doError(w, 401, "missing identity header")
 			return
 		}
+
+		if id.Identity.OrgID == "" || id.Identity.Internal.OrgID == "" {
+			doError(w, 400, "x-rh-identity header has an invalid or missing org_id")
+			return
+		}
+
 		if id.Identity.Type == "Associate" && id.Identity.AccountNumber == "" {
 			next.ServeHTTP(w, r)
 			return
@@ -107,11 +113,6 @@ func BasePolicy(next http.Handler) http.Handler {
 
 		if id.Identity.AccountNumber == "" || id.Identity.AccountNumber == "-1" {
 			doError(w, 400, "x-rh-identity header has an invalid or missing account number")
-			return
-		}
-
-		if id.Identity.OrgID == "" || id.Identity.Internal.OrgID == "" {
-			doError(w, 400, "x-rh-identity header has an invalid or missing org_id")
 			return
 		}
 

--- a/identity_suite_test.go
+++ b/identity_suite_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Identity", func() {
 
 	Context("With a valid x-rh-id header", func() {
 		It("should 200 and set the type to associate", func() {
-			req.Header.Set("x-rh-identity", getBase64(`{ "identity": {"type": "Associate"} }`))
+			req.Header.Set("x-rh-identity", getBase64(`{ "identity": {"type": "Associate", "internal": { "org_id": "1979710" } } }`))
 
 			boilerWithCustomHandler(req, 200, "", func() http.HandlerFunc {
 				fn := func(rw http.ResponseWriter, nreq *http.Request) {

--- a/identity_suite_test.go
+++ b/identity_suite_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Identity", func() {
 
 	Context("With missing account_number in the x-rh-id header", func() {
 		It("should throw a 400 with a descriptive message", func() {
-			req.Header.Set("x-rh-identity", getBase64(`{ "type": "User", "org_id": "1979710", "internal": { "org_id": "1979710" } }`))
+			req.Header.Set("x-rh-identity", getBase64(`{ "identity": { "type": "User", "org_id": "1979710", "internal": { "org_id": "1979710" } } }`))
 			boiler(req, 400, "Bad Request: x-rh-identity header has an invalid or missing account number\n")
 		})
 	})


### PR DESCRIPTION
Make sure we can always rely on the OrgID being set, even for Associates.

This avoids consumers of the identity library to handle the case where OrgID
is unset, which it should never be.

This will be helpful to osbuild/image-builder in moving from account_number
to org_id as tenant identifier.